### PR TITLE
Update building.html

### DIFF
--- a/building.html
+++ b/building.html
@@ -189,13 +189,13 @@ cd DVA5-master</pre>
 <p>The following commands are to be run in Powershell.</p>
 <ol>
     <li>
-        If building on Windows 7, the following are required for running Scoop:
+        If building on Windows 7 or Windows 8.1, the following are required for running Scoop:
         <ul>
             <li>
                 <a href="https://www.microsoft.com/en-us/download/details.aspx?id=30653" target="_blank">.NET Framework 4.5</a> or later.
             </li>
             <li>
-                Powershell 3 or later. Powershell 3 is superseded; Powershell 4 can be <a href="https://www.microsoft.com/en-us/download/details.aspx?id=40855" target="_blank">downloaded here</a>. You'll need the "Windows6.1" package, either x64 or x86 depending on your system.
+                Powershell 5 or later. Powershell 5 is superseded; Powershell 7.0 LTS can be <a href="https://github.com/PowerShell/PowerShell/releases/tag/v7.0.11" target="_blank">downloaded here</a>.
             </li>
         </ul>
     </li>


### PR DESCRIPTION
Update the information for installing Powershell 7.0 LTS on Windows 7 and 8.1, as Scoop no longer supports PowerShell versions 3 and 4.